### PR TITLE
Fix menuItem unloading

### DIFF
--- a/my_plugin.py
+++ b/my_plugin.py
@@ -5,6 +5,7 @@ import maya.cmds as cmds
 
 MENU_NAME = "ToolsMenu"  # no spaces in names, use CamelCase
 MENU_LABEL = "Tools"  # spaces are fine in labels
+MENU_ENTRY_NAME = "" # Store generated menu item, used when unregister
 MENU_ENTRY_LABEL = "My cool tool"
 
 MENU_PARENT = "MayaWindow"  # do not change
@@ -25,7 +26,7 @@ class HelloWorldCommand(om.MPxCommand):
     #     return HelloWorldCommand()
 
     def doIt(self, args):
-        print ("Hello World!")
+        print("Hello World!")
 
 
 def register_command(plugin):
@@ -53,18 +54,18 @@ def show(*args):
 
 
 def loadMenu():
+    global MENU_ENTRY_NAME
     if not cmds.menu(f"{MENU_PARENT}|{MENU_NAME}", exists=True):
         cmds.menu(MENU_NAME, label=MENU_LABEL, parent=MENU_PARENT)
-    cmds.menuItem(label=MENU_ENTRY_LABEL, command=show, parent=MENU_NAME)  
+    MENU_ENTRY_NAME = cmds.menuItem(label=MENU_ENTRY_LABEL, command=show, parent=MENU_NAME)
 
 
 def unloadMenuItem():
     if cmds.menu(f"{MENU_PARENT}|{MENU_NAME}", exists=True):
         menu_long_name = f"{MENU_PARENT}|{MENU_NAME}"
-        menu_item_long_name = f"{menu_long_name}|{MENU_ENTRY_LABEL}"
         # Check if the menu item exists; if it does, delete it
-        if cmds.menuItem(menu_item_long_name, exists=True):
-            cmds.deleteUI(menu_item_long_name, menuItem=True)
+        if cmds.menuItem(MENU_ENTRY_NAME, exists=True):
+            cmds.deleteUI(MENU_ENTRY_NAME, menuItem=True)
         # Check if the menu is now empty; if it is, delete the menu
         if not cmds.menu(menu_long_name, query=True, itemArray=True):
             cmds.deleteUI(menu_long_name, menu=True)

--- a/my_plugin.py
+++ b/my_plugin.py
@@ -9,7 +9,7 @@ MENU_ENTRY_LABEL = "My cool tool"
 
 MENU_PARENT = "MayaWindow"  # do not change
 
-__meun_entry_name = "" # Store generated menu item, used when unregister
+__menu_entry_name = "" # Store generated menu item, used when unregister
 
 def maya_useNewAPI():  # noqa
     pass  # dummy method to tell Maya this plugin uses Maya Python API 2.0
@@ -55,18 +55,18 @@ def show(*args):
 
 
 def loadMenu():
-    global __meun_entry_name
+    global __menu_entry_name
     if not cmds.menu(f"{MENU_PARENT}|{MENU_NAME}", exists=True):
         cmds.menu(MENU_NAME, label=MENU_LABEL, parent=MENU_PARENT)
-    __meun_entry_name = cmds.menuItem(label=MENU_ENTRY_LABEL, command=show, parent=MENU_NAME)
+    __menu_entry_name = cmds.menuItem(label=MENU_ENTRY_LABEL, command=show, parent=MENU_NAME)
 
 
 def unloadMenuItem():
     if cmds.menu(f"{MENU_PARENT}|{MENU_NAME}", exists=True):
         menu_long_name = f"{MENU_PARENT}|{MENU_NAME}"
         # Check if the menu item exists; if it does, delete it
-        if cmds.menuItem(__meun_entry_name, exists=True):
-            cmds.deleteUI(__meun_entry_name, menuItem=True)
+        if cmds.menuItem(__menu_entry_name, exists=True):
+            cmds.deleteUI(__menu_entry_name, menuItem=True)
         # Check if the menu is now empty; if it is, delete the menu
         if not cmds.menu(menu_long_name, query=True, itemArray=True):
             cmds.deleteUI(menu_long_name, menu=True)

--- a/my_plugin.py
+++ b/my_plugin.py
@@ -5,10 +5,11 @@ import maya.cmds as cmds
 
 MENU_NAME = "ToolsMenu"  # no spaces in names, use CamelCase
 MENU_LABEL = "Tools"  # spaces are fine in labels
-MENU_ENTRY_NAME = "" # Store generated menu item, used when unregister
 MENU_ENTRY_LABEL = "My cool tool"
 
 MENU_PARENT = "MayaWindow"  # do not change
+
+__meun_entry_name = "" # Store generated menu item, used when unregister
 
 def maya_useNewAPI():  # noqa
     pass  # dummy method to tell Maya this plugin uses Maya Python API 2.0
@@ -54,18 +55,18 @@ def show(*args):
 
 
 def loadMenu():
-    global MENU_ENTRY_NAME
+    global __meun_entry_name
     if not cmds.menu(f"{MENU_PARENT}|{MENU_NAME}", exists=True):
         cmds.menu(MENU_NAME, label=MENU_LABEL, parent=MENU_PARENT)
-    MENU_ENTRY_NAME = cmds.menuItem(label=MENU_ENTRY_LABEL, command=show, parent=MENU_NAME)
+    __meun_entry_name = cmds.menuItem(label=MENU_ENTRY_LABEL, command=show, parent=MENU_NAME)
 
 
 def unloadMenuItem():
     if cmds.menu(f"{MENU_PARENT}|{MENU_NAME}", exists=True):
         menu_long_name = f"{MENU_PARENT}|{MENU_NAME}"
         # Check if the menu item exists; if it does, delete it
-        if cmds.menuItem(MENU_ENTRY_NAME, exists=True):
-            cmds.deleteUI(MENU_ENTRY_NAME, menuItem=True)
+        if cmds.menuItem(__meun_entry_name, exists=True):
+            cmds.deleteUI(__meun_entry_name, menuItem=True)
         # Check if the menu is now empty; if it is, delete the menu
         if not cmds.menu(menu_long_name, query=True, itemArray=True):
             cmds.deleteUI(menu_long_name, menu=True)


### PR DESCRIPTION
When MAYA create the menuItem, it will generate a unique name for it. This name should be used when deleting the menu item instead of its label.